### PR TITLE
add app key generation to install instructions

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -11,6 +11,7 @@ Before you start make sure you're running PHP >= 5.6.4 and have
 composer install                # Install PHP dependencies
 cp .env.example .env            # Create .env config file
 vim .env                        # Update database credentials
+php artisan key:generate        # Create application key
 php artisan migrate             # Run database migrations
 php artisan passport:install    # Create Oauth2 Tokens
 ```


### PR DESCRIPTION
Without this step I get `RuntimeException: The only supported ciphers are AES-128-CBC and AES-256-CBC with the correct key lengths.`