### PR TITLE
[Feature] Transactions in batch voting

### DIFF
--- a/app/CandidateRank.php
+++ b/app/CandidateRank.php
@@ -6,7 +6,7 @@ use Illuminate\Database\Eloquent\Model;
 
 class CandidateRank extends Model
 {
-    protected $fillable = ['election_id', 'candidate_id'];
+    protected $fillable = ['election_id', 'candidate_id', 'rank', 'elector_id'];
 
     public function elector()
     {

--- a/app/Election.php
+++ b/app/Election.php
@@ -2,10 +2,14 @@
 
 namespace App;
 
-use Mail;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Support\Facades\Mail;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
 
+/**
+ * @property Collection electors
+ */
 class Election extends Model
 {
     use SoftDeletes;
@@ -26,18 +30,17 @@ class Election extends Model
 
     public function creator()
     {
-        return $this->belongsTo('App\User', 'creator_id');
+        return $this->belongsTo(User::class, 'creator_id');
     }
 
-    // TODO: why are we return Users from a function named electors?
     public function electors()
     {
-        return $this->belongsToMany('App\User', 'electors');
+        return $this->hasMany(Elector::class);
     }
 
     public function candidates()
     {
-        return $this->hasMany('App\Candidate');
+        return $this->hasMany(Candidate::class);
     }
 
     public function send_invite_email($email)

--- a/app/Election.php
+++ b/app/Election.php
@@ -33,6 +33,9 @@ class Election extends Model
         return $this->belongsTo(User::class, 'creator_id');
     }
 
+    /**
+     * @return \Illuminate\Database\Eloquent\Relations\HasMany|Elector
+     */
     public function electors()
     {
         return $this->hasMany(Elector::class);
@@ -65,7 +68,7 @@ class Election extends Model
 
     public function invite($email)
     {
-        $elector = $this->hasMany('App\Elector')->where(['invite_email' => $email])->first();
+        $elector = $this->electors()->where(['invite_email' => $email])->first();
         $mail_error = null;
 
         if (empty($elector))

--- a/app/Elector.php
+++ b/app/Elector.php
@@ -2,29 +2,36 @@
 
 namespace App;
 
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 
+/**
+ * Class Elector
+ *
+ * @package App
+ * @method self accepted()
+ */
 class Elector extends Model
 {
     public $timestamps = false;
 
     public function election()
     {
-        return $this->belongsTo('App\Election');
-    }
-
-    public function invite()
-    {
-        return $this->belongsTo('App\Invite');
+        return $this->belongsTo(Election::class);
     }
 
     public function user()
     {
-        return $this->belongsTo('App\User');
+        return $this->belongsTo(User::class);
     }
 
     public function ranks()
     {
-        return $this->hasMany('App\CandidateRank');
+        return $this->hasMany(CandidateRank::class);
+    }
+
+    public function scopeAccepted(Builder $query)
+    {
+        return $query->whereNotNull('invite_accepted_at');
     }
 }

--- a/app/Http/Controllers/ElectionController.php
+++ b/app/Http/Controllers/ElectionController.php
@@ -195,7 +195,7 @@ class ElectionController extends Controller
 
     public function batchvote_view(Request $request, $election_id)
     {
-        $election = Election::where('id', '=', $election_id)->firstOrFail();
+        $election = Election::findOrFail($election_id);
         $this->authorize('vote', $election);
 
         $elector = Elector::where('election_id', '=', $election_id)->

--- a/app/Http/Controllers/ElectorController.php
+++ b/app/Http/Controllers/ElectorController.php
@@ -44,7 +44,7 @@ class ElectorController extends Controller
     {
         $this->authorize('view_electors', $election);
 
-        return $election->electors;
+        return $election->electors()->accepted()->get();
     }
 
     /**
@@ -75,18 +75,14 @@ class ElectorController extends Controller
      * )
      *
      * @param  \App\Election $election
-     * @param  \App\User $user
      * @return \Illuminate\Http\Response
      */
-    public function show(Election $election, User $user)
+    public function show(Election $election, $elector_id)
     {
         $this->authorize('view_electors', $election);
 
-        if ($election->electors->contains($user)) {
-            return $user;
-        }
-
-        abort(404, 'Not Found');
+        $elector = $election->electors()->accepted()->whereKey($elector_id)->firstOrFail();
+        return $elector;
     }
 
     /**

--- a/app/Policies/ElectionPolicy.php
+++ b/app/Policies/ElectionPolicy.php
@@ -131,6 +131,6 @@ class ElectionPolicy
      */
     public function is_elector(Election $election, User $user)
     {
-        return $election->electors->contains($user);
+        return $election->electors()->where('user_id', $user->id)->exists();
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,10 @@
 {
     "name": "laravel/laravel",
     "description": "The Laravel Framework.",
-    "keywords": ["framework", "laravel"],
+    "keywords": [
+        "framework",
+        "laravel"
+    ],
     "license": "Apache-2.0",
     "type": "project",
     "repositories": [
@@ -11,14 +14,14 @@
         }
     ],
     "require": {
-        "php": ">=5.6.4",
+        "php": ">=7.1.3",
         "darkaonline/l5-swagger": "~5.0",
         "laravel/framework": "5.4.*",
         "laravel/passport": "^3.0",
         "laravel/tinker": "~1.0",
         "pivot-libre/tideman": "@dev",
-	"aws/aws-sdk-php": "~3.0",
-	"guzzlehttp/guzzle": "~6.0"
+        "aws/aws-sdk-php": "~3.0",
+        "guzzlehttp/guzzle": "~6.0"
     },
     "require-dev": {
         "fzaninotto/faker": "~1.4",

--- a/database/factories/ModelFactory.php
+++ b/database/factories/ModelFactory.php
@@ -22,3 +22,32 @@ $factory->define(App\User::class, function (Faker\Generator $faker) {
         'remember_token' => str_random(10),
     ];
 });
+
+/** @var \Illuminate\Database\Eloquent\Factory $factory */
+$factory->define(\App\Election::class, function (Faker\Generator $faker) {
+    return [
+        'name' => $faker->word,
+        'creator_id' => function() {
+            return factory(\App\User::class)->create()->id;
+        }
+    ];
+});
+
+/** @var \Illuminate\Database\Eloquent\Factory $factory */
+$factory->define(\App\Candidate::class, function (Faker\Generator $faker) {
+    return [
+        'name' => $faker->name,
+        'election_id' => function() {
+            return factory(\App\Election::class)->create()->id;
+        }
+    ];
+});
+
+/** @var \Illuminate\Database\Eloquent\Factory $factory */
+$factory->define(\App\Elector::class, function (Faker\Generator $faker) {
+    return [
+        'election_id' => function() {
+            return factory(\App\Election::class)->create()->id;
+        }
+    ];
+});

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Route;
 
 /*
 |--------------------------------------------------------------------------
@@ -31,7 +32,7 @@ Route::get('election/{election_id}/batch_candidates', 'ElectionController@batch_
 Route::resource('election.candidate', 'CandidateController', ['only' => ['index', 'show', 'store', 'destroy']]);
 
 Route::resource('election.elector', 'ElectorController', ['only' => ['index', 'show', 'destroy'],
-    'parameters' => ['elector' => 'user'],
+                                                          'parameters' => ['elector' => 'user'],
 ]);
 
 // TODO: get rid of election result, moving call to election controller

--- a/tests/Feature/ElectionTest.php
+++ b/tests/Feature/ElectionTest.php
@@ -15,13 +15,59 @@ use Tests\TestCase;
 
 class ElectionTest extends TestCase
 {
-    use DatabaseMigrations, DatabaseTransactions;
+    use DatabaseTransactions;
 
     /** @test */
     public function can_batch_vote()
     {
-        $this->disableExceptionHandling();
+        $user = factory(User::class)->create();
 
+        $election = factory(Election::class)->create();
+
+        /** @var Elector $elector */
+        $elector = factory(Elector::class)->create([
+            'user_id' => $user->id,
+            'election_id' => $election->id,
+        ]);
+
+        $candidateA = factory(Candidate::class)->create([
+            'name' => 'candidate-A',
+            'election_id' => $election->id,
+        ]);
+        $candidateB = factory(Candidate::class)->create([
+            'name' => 'candidate-B',
+            'election_id' => $election->id,
+        ]);
+        $candidateC = factory(Candidate::class)->create([
+            'name' => 'candidate-C',
+            'election_id' => $election->id,
+        ]);
+
+        $this->assertEquals(0, $elector->ranks()->count());
+        $response = $this->actingAs($user, 'api')->postJson("api/election/{$election->id}/batchvote", [
+            'votes' => [
+                [
+                    'candidate_id' => $candidateA->id,
+                    'rank' => 2
+                ],
+                [
+                    'candidate_id' => $candidateB->id,
+                    'rank' => 1
+                ],
+                [
+                    'candidate_id' => $candidateC->id,
+                    'rank' => 3
+                ]
+            ]
+        ]);
+
+        $response->assertStatus(200);
+        $this->assertEquals(3, $elector->ranks()->count());
+    }
+
+    /** @test */
+    public function can_batch_vote_when_()
+    {
         $user = factory(User::class)->create();
 
         $election = factory(Election::class)->create();

--- a/tests/Feature/ElectionTest.php
+++ b/tests/Feature/ElectionTest.php
@@ -1,0 +1,92 @@
+<?php
+
+
+namespace Tests\Feature;
+
+
+use App\Candidate;
+use App\Election;
+use App\Elector;
+use App\User;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Foundation\Testing\DatabaseMigrations;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Tests\TestCase;
+
+class ElectionTest extends TestCase
+{
+    use DatabaseMigrations, DatabaseTransactions;
+
+    /** @test */
+    public function can_batch_vote()
+    {
+        $this->disableExceptionHandling();
+
+        $user = factory(User::class)->create();
+
+        $election = factory(Election::class)->create();
+
+        /** @var Elector $elector */
+        $elector = factory(Elector::class)->create([
+            'user_id' => $user->id,
+            'election_id' => $election->id,
+        ]);
+
+        $candidateA = factory(Candidate::class)->create([
+            'name' => 'candidate-A',
+            'election_id' => $election->id,
+        ]);
+        $candidateB = factory(Candidate::class)->create([
+            'name' => 'candidate-B',
+            'election_id' => $election->id,
+        ]);
+        $candidateC = factory(Candidate::class)->create([
+            'name' => 'candidate-C',
+            'election_id' => $election->id,
+        ]);
+
+        $this->assertEquals(0, $elector->ranks()->count());
+        $response = $this->actingAs($user, 'api')->postJson("api/election/{$election->id}/batchvote", [
+            'votes' => [
+                [
+                    'candidate_id' => $candidateA->id,
+                    'rank' => 2
+                ],
+                [
+                    'candidate_id' => $candidateB->id,
+                    'rank' => 1
+                ],
+                [
+                    'candidate_id' => $candidateC->id,
+                    'rank' => 3
+                ]
+            ]
+        ]);
+
+        $response->assertStatus(200);
+        $this->assertEquals(3, $elector->ranks()->count());
+    }
+
+    /** @test */
+    public function cannot_batch_vote_if_invalid_election_id()
+    {
+        $user = factory(User::class)->create();
+
+        $election = factory(Election::class)->create();
+
+        $candidateA = factory(Candidate::class)->create([
+            'name' => 'candidate-A'
+        ]);
+
+        $invalidElectionId = $election->id + 9999;
+        $response = $this->actingAs($user, 'api')->postJson("api/election/{$invalidElectionId}/batchvote", [
+            'votes' => [
+                [
+                    'candidate_id' => $candidateA->id,
+                    'rank' => 2
+                ],
+            ]
+        ]);
+        $this->assertInstanceOf(ModelNotFoundException::class, $response->exception);
+    }
+}

--- a/tests/Feature/ElectionTest.php
+++ b/tests/Feature/ElectionTest.php
@@ -18,6 +18,25 @@ class ElectionTest extends TestCase
     use DatabaseTransactions;
 
     /** @test */
+    public function can_get_a_election()
+    {
+        $user = factory(User::class)->create();
+
+        $election = factory(Election::class)->create();
+
+        /** @var Elector $elector */
+        $elector = factory(Elector::class)->create([
+            'user_id' => $user->id,
+            'election_id' => $election->id,
+        ]);
+
+        $response = $this->actingAs($user, 'api')->getJson("api/election/{$election->id}");
+
+        $response->assertStatus(200);
+        $this->assertInstanceOf(Election::class, $response->getOriginalContent());
+    }
+
+    /** @test */
     public function can_batch_vote()
     {
         $user = factory(User::class)->create();

--- a/tests/Feature/ElectionTest.php
+++ b/tests/Feature/ElectionTest.php
@@ -66,54 +66,6 @@ class ElectionTest extends TestCase
     }
 
     /** @test */
-    public function can_batch_vote_when_()
-    {
-        $user = factory(User::class)->create();
-
-        $election = factory(Election::class)->create();
-
-        /** @var Elector $elector */
-        $elector = factory(Elector::class)->create([
-            'user_id' => $user->id,
-            'election_id' => $election->id,
-        ]);
-
-        $candidateA = factory(Candidate::class)->create([
-            'name' => 'candidate-A',
-            'election_id' => $election->id,
-        ]);
-        $candidateB = factory(Candidate::class)->create([
-            'name' => 'candidate-B',
-            'election_id' => $election->id,
-        ]);
-        $candidateC = factory(Candidate::class)->create([
-            'name' => 'candidate-C',
-            'election_id' => $election->id,
-        ]);
-
-        $this->assertEquals(0, $elector->ranks()->count());
-        $response = $this->actingAs($user, 'api')->postJson("api/election/{$election->id}/batchvote", [
-            'votes' => [
-                [
-                    'candidate_id' => $candidateA->id,
-                    'rank' => 2
-                ],
-                [
-                    'candidate_id' => $candidateB->id,
-                    'rank' => 1
-                ],
-                [
-                    'candidate_id' => $candidateC->id,
-                    'rank' => 3
-                ]
-            ]
-        ]);
-
-        $response->assertStatus(200);
-        $this->assertEquals(3, $elector->ranks()->count());
-    }
-
-    /** @test */
     public function cannot_batch_vote_if_invalid_election_id()
     {
         $user = factory(User::class)->create();

--- a/tests/Feature/ElectorTest.php
+++ b/tests/Feature/ElectorTest.php
@@ -1,0 +1,143 @@
+<?php
+
+
+namespace Tests\Feature;
+
+
+use App\Election;
+use App\Elector;
+use App\User;
+use Carbon\Carbon;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Tests\TestCase;
+
+class ElectorTest extends TestCase
+{
+
+    /** @test */
+    public function can_get_electors()
+    {
+        $user = factory(User::class)->create();
+
+        $election = factory(Election::class)->create();
+
+        // Accepted invite
+        $electorA = factory(Elector::class)->create([
+            'user_id' => $user->id,
+            'election_id' => $election->id,
+            'invite_accepted_at' => Carbon::now()
+        ]);
+
+        // Non-accepted invite
+        $electorWithoutUser = factory(Elector::class)->create([
+            'election_id' => $election->id,
+        ]);
+
+        // Accepted invite, but in other election.
+        $electorNotInElection = factory(Elector::class)->create([
+            'user_id' => $user->id,
+            'invite_accepted_at' => Carbon::now()
+        ]);
+
+        $response = $this->actingAs($user, 'api')->getJson("api/election/{$election->id}/elector");
+
+        $response->assertStatus(200);
+        $electors = $response->getOriginalContent();
+        $this->assertCount(1, $electors);
+        $this->assertTrue($electorA->is($electors->get(0)));
+    }
+
+    /** @test */
+    public function can_get_a_specific_elector()
+    {
+        $user = factory(User::class)->create();
+
+        $election = factory(Election::class)->create();
+
+        // Accepted invite
+        $electorA = factory(Elector::class)->create([
+            'user_id' => $user->id,
+            'election_id' => $election->id,
+            'invite_accepted_at' => Carbon::now()
+        ]);
+
+        // Non-accepted invite
+        $electorWithoutUser = factory(Elector::class)->create([
+            'election_id' => $election->id,
+        ]);
+
+        // Accepted invite, but in other election.
+        $electorNotInElection = factory(Elector::class)->create([
+            'user_id' => $user->id,
+            'invite_accepted_at' => Carbon::now()
+        ]);
+
+        $response = $this->actingAs($user, 'api')->getJson("api/election/{$election->id}/elector/{$electorA->id}");
+
+        $response->assertStatus(200);
+        $this->assertTrue($electorA->is($response->getOriginalContent()));
+    }
+
+    /** @test */
+    public function cannot_get_a_specific_elector_where_invite_not_accepted()
+    {
+        $user = factory(User::class)->create();
+
+        $election = factory(Election::class)->create();
+
+        // Accepted invite
+        $electorA = factory(Elector::class)->create([
+            'user_id' => $user->id,
+            'election_id' => $election->id,
+            'invite_accepted_at' => Carbon::now()
+        ]);
+
+        // Non-accepted invite
+        $electorWithoutUser = factory(Elector::class)->create([
+            'election_id' => $election->id,
+        ]);
+
+        // Accepted invite, but in other election.
+        $electorNotInElection = factory(Elector::class)->create([
+            'user_id' => $user->id,
+            'invite_accepted_at' => Carbon::now()
+        ]);
+
+        $response = $this->actingAs($user, 'api')->getJson("api/election/{$election->id}/elector/{$electorWithoutUser->id}");
+
+        $this->assertInstanceOf(ModelNotFoundException::class, $response->exception);
+    }
+
+
+    /** @test */
+    public function cannot_get_a_specific_elector_which_belongs_to_other_election()
+    {
+        $user = factory(User::class)->create();
+
+        $election = factory(Election::class)->create();
+
+        // Accepted invite
+        $electorA = factory(Elector::class)->create([
+            'user_id' => $user->id,
+            'election_id' => $election->id,
+            'invite_accepted_at' => Carbon::now()
+        ]);
+
+        // Non-accepted invite
+        $electorWithoutUser = factory(Elector::class)->create([
+            'election_id' => $election->id,
+        ]);
+
+        // Accepted invite, but in other election.
+        $electorNotInElection = factory(Elector::class)->create([
+            'user_id' => $user->id,
+            'invite_accepted_at' => Carbon::now()
+        ]);
+
+        $response = $this->actingAs($user, 'api')->getJson("api/election/{$election->id}/elector/{$electorNotInElection->id}");
+
+        $this->assertInstanceOf(ModelNotFoundException::class, $response->exception);
+    }
+
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,9 +2,28 @@
 
 namespace Tests;
 
+use Illuminate\Contracts\Debug\ExceptionHandler;
 use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
+use App\Exceptions\Handler;
+
 
 abstract class TestCase extends BaseTestCase
 {
     use CreatesApplication;
+
+    protected function disableExceptionHandling()
+    {
+        app()->instance(ExceptionHandler::class, new class extends Handler {
+            public function __construct() {
+            }
+            public function report(\Exception $e)
+            {
+                // no-op
+            }
+            public function render($request, \Exception $e)
+            {
+                throw $e;
+            }
+        });
+    }
 }

--- a/tests/python/tests.py
+++ b/tests/python/tests.py
@@ -262,12 +262,14 @@ def test1(api):
     invite_status = api.invite(userA, election, userB['email'])
     code = invite_status['code']
     electors = api.get_electors(userA, election)
+    print(electors)
     assert(len(electors) == 1)
     acceptables = api.acceptable(userB)
     codes = [inv['code'] for inv in acceptables]
     assert (code in codes)
     api.accept(userB, code)
     electors = api.get_electors(userA, election)
+    print(electors)
     assert(len(electors) == 2)
 
     # verify B can now see it after being added


### PR DESCRIPTION
When voting in batches, we need to do it as transactions as we else can have some big problems where only some of the candidate ranks gets commited to the database. This commit also includes some validations for batch voting, so now we are checking if candidate id is valid with the use of Laravel validation.

Commit includes:
- Transaction for batch voting
- Validation in batch voting
- Refactoring of batch voting
- Force PHP 7.1 as docs says that is required
- Small fixes for different models
- Example unit tests

Resolves: #94