### PR TITLE
fix HTTP post to pass array

### DIFF
--- a/public/js/create.js
+++ b/public/js/create.js
@@ -19,7 +19,7 @@ Piv.html(NewElectionForm, "input", "", {"type": "submit", "value": "Create"});
 // function definitions
 function createElection(form) {
   var name = form.elements.electionName.value
-  Piv.http.post("/api/election", [{"name": name}], function(response) {
+  Piv.http.post(["/api/election"], [{"name": name}], function(response) {
     window.location.href = "/administer/" + response.id
   })
 }

--- a/public/js/deleteAccount.js
+++ b/public/js/deleteAccount.js
@@ -9,7 +9,7 @@
 
     // function definitions
     function deleteAccount(form) {
-	Piv.http.post("/api/delete_account", [{}], function(response) {
+	Piv.http.post(["/api/delete_account"], [{}], function(response) {
 	    alert(response);
 	})
     }


### PR DESCRIPTION
Otherwise, it treats the endpoint string as an array, and does a bunch of POSTs like this:
POST homestead.test/a
POST homestead.test/p
POST homestead.test/i
POST homestead.test/e
POST homestead.test/l