### PR TITLE
Feat: API endpoint update and tests

### DIFF
--- a/app/Candidate.php
+++ b/app/Candidate.php
@@ -6,14 +6,18 @@ use Illuminate\Database\Eloquent\Model;
 
 class Candidate extends Model
 {
+    protected $fillable = [
+        'name'
+    ];
+
     public function election()
     {
-        return $this->belongsTo('App\Election');
+        return $this->belongsTo(Election::class);
     }
 
     public function ranks()
     {
-        return $this->hasMany('App\CandidateRank');
+        return $this->hasMany(CandidateRank::class);
     }
 
     // TODO: allow admin to specify candidate order

--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -4,6 +4,7 @@ namespace App\Exceptions;
 
 use Exception;
 use Illuminate\Auth\AuthenticationException;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Foundation\Exceptions\Handler as ExceptionHandler;
 
 class Handler extends ExceptionHandler
@@ -66,6 +67,10 @@ class Handler extends ExceptionHandler
             if ($this->isHttpException($exception)) {
                 // Grab the HTTP status code from the Exception
                 $status = $exception->getStatusCode();
+            } elseif ($exception instanceof ModelNotFoundException) {
+                $status = 404;
+                $model = class_basename($exception->getModel());
+                $response['errors'] = "Couldn't find the requested resource [{$model}].";
             }
 
             // Return a JSON response with the response array and status code

--- a/app/Http/Controllers/AccountController.php
+++ b/app/Http/Controllers/AccountController.php
@@ -11,11 +11,6 @@ use Illuminate\Support\Facades\Config;
 
 class AccountController extends Controller
 {
-    public function __construct()
-    {
-        $this->middleware('auth:api');
-    }
-
     public function delete_account(Request $request)
     {
         $user = Auth::user();

--- a/app/Http/Controllers/CandidateController.php
+++ b/app/Http/Controllers/CandidateController.php
@@ -18,7 +18,7 @@ class CandidateController extends Controller
      *
      * @SWG\Get(
      *     tags={"Candidates"},
-     *     path="/election/{electionId}/candidate",
+     *     path="/elections/{electionId}/candidate",
      *     summary="View candidates for an election",
      *     operationId="candidateIndex",
      *     @SWG\Parameter(
@@ -49,7 +49,7 @@ class CandidateController extends Controller
      *
      * @SWG\Get(
      *     tags={"Candidates"},
-     *     path="/election/{electionId}/candidate/{candidateId}",
+     *     path="/elections/{electionId}/candidate/{candidateId}",
      *     summary="Get information about a candidate",
      *     operationId="getCandidateById",
      *     @SWG\Parameter(
@@ -87,7 +87,7 @@ class CandidateController extends Controller
      *
      * @SWG\Post(
      *     tags={"Candidates"},
-     *     path="/election/{electionId}/candidate",
+     *     path="/elections/{electionId}/candidate",
      *     summary="Add a candidate",
      *     consumes={"application/json"},
      *     produces={"application/json"},
@@ -142,7 +142,7 @@ class CandidateController extends Controller
      *
      * @SWG\Delete(
      *     tags={"Candidates"},
-     *     path="/election/{electionId}/candidate/{candidateId}",
+     *     path="/elections/{electionId}/candidate/{candidateId}",
      *     summary="Delete a candidate",
      *     consumes={"application/json"},
      *     produces={"application/json"},

--- a/app/Http/Controllers/CandidateController.php
+++ b/app/Http/Controllers/CandidateController.php
@@ -18,7 +18,7 @@ class CandidateController extends Controller
      *
      * @SWG\Get(
      *     tags={"Candidates"},
-     *     path="/elections/{electionId}/candidate",
+     *     path="/elections/{electionId}/candidates",
      *     summary="View candidates for an election",
      *     operationId="candidateIndex",
      *     @SWG\Parameter(
@@ -49,7 +49,7 @@ class CandidateController extends Controller
      *
      * @SWG\Get(
      *     tags={"Candidates"},
-     *     path="/elections/{electionId}/candidate/{candidateId}",
+     *     path="/elections/{electionId}/candidates/{candidateId}",
      *     summary="Get information about a candidate",
      *     operationId="getCandidateById",
      *     @SWG\Parameter(
@@ -87,7 +87,7 @@ class CandidateController extends Controller
      *
      * @SWG\Post(
      *     tags={"Candidates"},
-     *     path="/elections/{electionId}/candidate",
+     *     path="/elections/{electionId}/candidates",
      *     summary="Add a candidate",
      *     consumes={"application/json"},
      *     produces={"application/json"},
@@ -142,7 +142,7 @@ class CandidateController extends Controller
      *
      * @SWG\Delete(
      *     tags={"Candidates"},
-     *     path="/elections/{electionId}/candidate/{candidateId}",
+     *     path="/elections/{electionId}/candidates/{candidateId}",
      *     summary="Delete a candidate",
      *     consumes={"application/json"},
      *     produces={"application/json"},

--- a/app/Http/Controllers/CandidateController.php
+++ b/app/Http/Controllers/CandidateController.php
@@ -8,11 +8,6 @@ use Illuminate\Http\Request;
 
 class CandidateController extends Controller
 {
-    public function __construct()
-    {
-        $this->middleware('auth:api');
-    }
-
     /**
      * Display a listing of the resource.
      *

--- a/app/Http/Controllers/ElectionController.php
+++ b/app/Http/Controllers/ElectionController.php
@@ -12,11 +12,6 @@ use Illuminate\Support\Facades\DB;
 
 class ElectionController extends Controller
 {
-    public function __construct()
-    {
-        $this->middleware('auth:api');
-    }
-
     /**
      * @SWG\Get(
      *     tags={"Election"},

--- a/app/Http/Controllers/ElectionController.php
+++ b/app/Http/Controllers/ElectionController.php
@@ -20,7 +20,7 @@ class ElectionController extends Controller
     /**
      * @SWG\Get(
      *     tags={"Election"},
-     *     path="/election",
+     *     path="/elections",
      *     operationId="electionIndex",
      *     summary="View all elections",
      *     @SWG\Response(response="200", description="Success", @SWG\Schema(
@@ -91,7 +91,7 @@ class ElectionController extends Controller
      *
      * * @SWG\Get(
      *     tags={"Election"},
-     *     path="/election/{electionId}",
+     *     path="/elections/{electionId}",
      *     summary="View information about an election",
      *     operationId="getElectionById",
      *     @SWG\Parameter(

--- a/app/Http/Controllers/ElectorController.php
+++ b/app/Http/Controllers/ElectorController.php
@@ -10,11 +10,6 @@ use Illuminate\Http\Request;
 
 class ElectorController extends Controller
 {
-    public function __construct()
-    {
-        $this->middleware('auth:api');
-    }
-
     /**
      * Display a listing of the resource.
      *

--- a/app/Http/Controllers/ElectorController.php
+++ b/app/Http/Controllers/ElectorController.php
@@ -20,7 +20,7 @@ class ElectorController extends Controller
      *
      * @SWG\Get(
      *     tags={"Electors"},
-     *     path="/elections/{electionId}/elector",
+     *     path="/elections/{electionId}/electors",
      *     summary="View the electorate for an election",
      *     operationId="electorIndex",
      *     @SWG\Parameter(
@@ -52,7 +52,7 @@ class ElectorController extends Controller
      *
      * @SWG\Get(
      *     tags={"Electors"},
-     *     path="/elections/{electionId}/elector/{electorId}",
+     *     path="/elections/{electionId}/electors/{electorId}",
      *     summary="Get information about an elector",
      *     operationId="getElectorById",
      *     @SWG\Parameter(

--- a/app/Http/Controllers/ElectorController.php
+++ b/app/Http/Controllers/ElectorController.php
@@ -20,7 +20,7 @@ class ElectorController extends Controller
      *
      * @SWG\Get(
      *     tags={"Electors"},
-     *     path="/election/{electionId}/elector",
+     *     path="/elections/{electionId}/elector",
      *     summary="View the electorate for an election",
      *     operationId="electorIndex",
      *     @SWG\Parameter(
@@ -52,7 +52,7 @@ class ElectorController extends Controller
      *
      * @SWG\Get(
      *     tags={"Electors"},
-     *     path="/election/{electionId}/elector/{electorId}",
+     *     path="/elections/{electionId}/elector/{electorId}",
      *     summary="Get information about an elector",
      *     operationId="getElectorById",
      *     @SWG\Parameter(

--- a/app/Http/Controllers/InviteController.php
+++ b/app/Http/Controllers/InviteController.php
@@ -20,7 +20,7 @@ class InviteController extends Controller
      *
      * @SWG\Get(
      *     tags={"Invites"},
-     *     path="/election/{electionId}/invite",
+     *     path="/elections/{electionId}/invite",
      *     summary="View electors who have not accepted their invite yet",
      *     operationId="inviteIndex",
      *     @SWG\Parameter(
@@ -51,7 +51,7 @@ class InviteController extends Controller
      *
      * @SWG\Post(
      *     tags={"Invites"},
-     *     path="/election/{electionId}/invite",
+     *     path="/elections/{electionId}/invite",
      *     summary="Send an invite",
      *     operationId="createInvite",
      *     consumes={"application/json"},

--- a/app/Http/Controllers/InviteController.php
+++ b/app/Http/Controllers/InviteController.php
@@ -10,11 +10,6 @@ use Illuminate\Support\Facades\Auth;
 
 class InviteController extends Controller
 {
-    public function __construct()
-    {
-        $this->middleware('auth:api');
-    }
-
     /**
      * Display a listing of the resource.
      *

--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -9,16 +9,6 @@ use Illuminate\Support\Facades\Session;
 class ProfileController extends Controller
 {
     /**
-     * Create a new controller instance.
-     *
-     * @return void
-     */
-    public function __construct()
-    {
-        $this->middleware('auth');
-    }
-
-    /**
      * Show the application dashboard.
      *
      * @return \Illuminate\Http\Response

--- a/app/Http/Controllers/ResultController.php
+++ b/app/Http/Controllers/ResultController.php
@@ -3,6 +3,7 @@ namespace App\Http\Controllers;
 
 use App\Election;
 use App\CandidateRank;
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use PivotLibre\Tideman\Agenda;
@@ -15,14 +16,9 @@ use PivotLibre\Tideman\Grouper;
 
 class ResultController extends Controller
 {
-    public function __construct()
-    {
-        $this->middleware('auth:api');
-    }
-
     /**
      * @param int $electionId
-     * @return Illuminate\Collection of all CandidateRanks associated with
+     * @return Collection of all CandidateRanks associated with
      * the election identified by the parameterized  id.
      */
     public function getCandidateRankCollection($electionId)
@@ -52,7 +48,7 @@ class ResultController extends Controller
     }
 
     /**
-     * @param Illuminate\Database\Eloquent\Relations\Collection of App\CandidateRank
+     * @param Collection of App\CandidateRank
      * @return array of arrays of arrays. The arrays are grouped at the outermost level
      * on elector id. The arrays are grouped at the next level by rank. Array entries at this level are ordered in
      * ascending rank. The innermost arrays are associative arrays that contain CandidateRank attributes.

--- a/app/Http/Controllers/VerifyController.php
+++ b/app/Http/Controllers/VerifyController.php
@@ -11,11 +11,6 @@ use Illuminate\Support\Facades\Config;
 
 class VerifyController extends Controller
 {
-    public function __construct()
-    {
-        $this->middleware('web');
-    }
-
     public function send_verify_email(Request $request)
     {
         // don't even try if the mail driver is not configured

--- a/app/Policies/ElectionPolicy.php
+++ b/app/Policies/ElectionPolicy.php
@@ -19,7 +19,7 @@ class ElectionPolicy
      */
     public function view(User $user, Election $election)
     {
-        return $this->is_admin($election, $user) || $this->is_elector($election, $user);
+        return $user->isAdmin($election) || $user->isElector($election);
     }
 
     /**
@@ -32,7 +32,7 @@ class ElectionPolicy
     public function view_electors(User $user, Election $election)
     {
         // TODO: should electors be able to see other electors?
-        return $this->is_admin($election, $user) || $this->is_elector($election, $user);
+        return $user->isAdmin($election) || $user->isElector($election);
     }
 
     /**
@@ -45,7 +45,7 @@ class ElectionPolicy
     public function view_results(User $user, Election $election)
     {
         // TODO: should electors be able to view results?
-        return $this->is_admin($election, $user) || $this->is_elector($election, $user);
+        return $user->isAdmin($election) || $user->isElector($election);
     }
 
     /**
@@ -58,7 +58,7 @@ class ElectionPolicy
     public function view_voter_stats(User $user, Election $election)
     {
         // TODO: should electors be able to view stats?
-        return $this->is_admin($election, $user) || $this->is_elector($election, $user);
+        return $user->isAdmin($election) || $user->isElector($election);
     }
 
     /**
@@ -71,7 +71,7 @@ class ElectionPolicy
     public function view_voter_details(User $user, Election $election)
     {
         // TODO: should electors be able to view list of other electors?
-        return $this->is_admin($election, $user);
+        return $user->isAdmin($election);
     }
 
     /**
@@ -83,7 +83,7 @@ class ElectionPolicy
      */
     public function vote(User $user, Election $election)
     {
-        return $this->is_elector($election, $user);
+        return $user->isElector($election);
     }
     
     /**
@@ -95,7 +95,7 @@ class ElectionPolicy
      */
     public function update(User $user, Election $election)
     {
-        return $this->is_admin($election, $user);
+        return $user->isAdmin($election);
     }
 
     /**
@@ -107,30 +107,6 @@ class ElectionPolicy
      */
     public function delete(User $user, Election $election)
     {
-        return $this->is_admin($election, $user);
-    }
-
-    /**
-     * Determine whether the user is an election admin
-     *
-     * @param  \App\User  $user
-     * @param  \App\Election  $election
-     * @return bool
-     */
-    public function is_admin(Election $election, User $user)
-    {
-        return $election->creator->is($user);
-    }
-
-    /**
-     * Determine whether the user is an election admin
-     *
-     * @param  \App\User  $user
-     * @param  \App\Election  $election
-     * @return bool
-     */
-    public function is_elector(Election $election, User $user)
-    {
-        return $election->electors()->where('user_id', $user->id)->exists();
+        return $user->isAdmin($election);
     }
 }

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -2,6 +2,8 @@
 
 namespace App\Providers;
 
+use App\Election;
+use App\Policies\ElectionPolicy;
 use Laravel\Passport\Passport;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
@@ -14,7 +16,7 @@ class AuthServiceProvider extends ServiceProvider
      * @var array
      */
     protected $policies = [
-        'App\Election' => 'App\Policies\ElectionPolicy',
+        Election::class  => ElectionPolicy::class,
     ];
 
     /**

--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace App\Providers;
 
+use App\Candidate;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Foundation\Support\Providers\RouteServiceProvider as ServiceProvider;
 
@@ -24,6 +25,9 @@ class RouteServiceProvider extends ServiceProvider
     public function boot()
     {
         parent::boot();
+        Route::bind('candidate', function ($value) {
+            return Candidate::whereKey($value)->where('election_id', Route::current()->parameter('election'))->first();
+        });
     }
 
     /**

--- a/app/User.php
+++ b/app/User.php
@@ -32,4 +32,12 @@ class User extends Authenticatable
     {
         return $this->belongsToMany('App\Election', 'electors');
     }
+
+    public function isAdmin(Election $election) {
+        return $election->creator->is($this);
+    }
+
+    public function isElector(Election $election) {
+        return $election->electors()->where('user_id', $this->id)->exists();
+    }
 }

--- a/public/js/administer.js
+++ b/public/js/administer.js
@@ -20,7 +20,7 @@ Piv.anchorListDiv(View.workspace, "", {
 
 Piv.removeHrefsForCurrentLoc()  //remove hrefs that link to the current page
 
-Piv.http.get(["/api/election/" + ElectionId, "/api/election/" + ElectionId + "/voter_stats"], showElectionDetails)
+Piv.http.get(["/api/elections/" + ElectionId, "/api/elections/" + ElectionId + "/voter_stats"], showElectionDetails)
 
 // function definitions
 function showElectionDetails(details, stats) {
@@ -37,7 +37,7 @@ function showElectionDetails(details, stats) {
 }
 function deleteElection(electionId) {
   if (!electionId) {return}
-  axios.delete('/api/election/' + electionId)
+  axios.delete('/api/elections/' + electionId)
     .then(response => {
       // console.log(response.data);
       window.location.href = "/myElections"

--- a/public/js/ballot.js
+++ b/public/js/ballot.js
@@ -30,7 +30,7 @@ ReviewedStatusDomels.checkbox = Piv.checkbox(reviewedButton, "reviewedStatusChec
       ReviewedStatusDomels.messageDiv.parentElement.removeChild(ReviewedStatusDomels.messageDiv)
       delete ReviewedStatusDomels.messageDiv
     }
-    Piv.http.post(["/api/election/" + ElectionId + "/set_ready"], [{"approved_version": ReviewedStatusDomels.version}], function(response) {
+    Piv.http.post(["/api/elections/" + ElectionId + "/set_ready"], [{"approved_version": ReviewedStatusDomels.version}], function(response) {
       if (!response.is_latest) {
         ReviewedStatusDomels.checkbox.input.checked = false
         Piv.loadBallot(ElectionId, Piv.displayBallot, li1)
@@ -40,11 +40,11 @@ ReviewedStatusDomels.checkbox = Piv.checkbox(reviewedButton, "reviewedStatusChec
     })
   }
   else {
-    Piv.http.post(["/api/election/" + ElectionId + "/set_ready"], [{"approved_version": null}], function(response) {
+    Piv.http.post(["/api/elections/" + ElectionId + "/set_ready"], [{"approved_version": null}], function(response) {
     })
   }
 })
-Piv.http.get(["/api/election/" + ElectionId + "/get_ready"], function(response) {
+Piv.http.get(["/api/elections/" + ElectionId + "/get_ready"], function(response) {
   ReviewedStatusDomels.version = response.latest_version
   ReviewedStatusDomels.checkbox.input.checked = ReviewedStatusDomels.isApproved = response.is_latest
 })
@@ -293,7 +293,7 @@ function candidatesToArray(candidates, targetArray, isRanked) {
 };
 function batchVote(electionId, candidateRanks) {
   if (!electionId) {return}
-  Piv.http.post(["/api/election/" + electionId + "/batchvote"], [candidateRanks], finishSaveRankings)
+  Piv.http.post(["/api/elections/" + electionId + "/batchvote"], [candidateRanks], finishSaveRankings)
 }
 
 // close the self-executing function and feed the piv library to it

--- a/public/js/candidates.js
+++ b/public/js/candidates.js
@@ -41,7 +41,7 @@ function loadCandidates(electionId, onSuccessFunction) {
   if (!electionId) return
   // (candidate and batch_candidates are the same)
   // Piv.http.get1('/api/election/' + electionId + "/candidate", onSuccessFunction)
-  Piv.http.get(["/api/election/" + electionId + "/batch_candidates"], onSuccessFunction)
+  Piv.http.get(["/api/elections/" + electionId + "/batch_candidates"], onSuccessFunction)
 }
 function revertChanges() {
   if (SaveInProgress) {
@@ -146,7 +146,7 @@ function saveCandidates(electionId) {
   var innerHtml = SaveCandidatesButton.innerHTML
 
   for (var i in CandidateDirectory.indexes.deleted) {
-    deleteResources.push("/api/election/" + electionId + "/candidate/" + CandidateDirectory.indexes.deleted[i].id)
+    deleteResources.push("/api/elections/" + electionId + "/candidates/" + CandidateDirectory.indexes.deleted[i].id)
   }
   if (deleteResources.length > 0) {
     SaveCandidatesButton.innerHTML = "Deleting..."
@@ -181,7 +181,7 @@ function saveCandidateList(electionId, innerHtml) {
     updateSaveButton()
     return
   }
-  Piv.http.post(["/api/election/" + electionId + "/batch_candidates"], [{"candidates": newAndChangedCandidates}], function(candidates) {
+  Piv.http.post(["/api/elections/" + electionId + "/batch_candidates"], [{"candidates": newAndChangedCandidates}], function(candidates) {
     displayCandidates(candidates)
     SaveInProgress = false
     SaveCandidatesButton.innerHTML = innerHtml

--- a/public/js/create.js
+++ b/public/js/create.js
@@ -19,7 +19,7 @@ Piv.html(NewElectionForm, "input", "", {"type": "submit", "value": "Create"});
 // function definitions
 function createElection(form) {
   var name = form.elements.electionName.value
-  Piv.http.post(["/api/election"], [{"name": name}], function(response) {
+  Piv.http.post(["/api/elections"], [{"name": name}], function(response) {
     window.location.href = "/administer/" + response.id
   })
 }

--- a/public/js/electorate.js
+++ b/public/js/electorate.js
@@ -105,7 +105,7 @@ function sendInvites() {
       continue
     }
     emails[email] = true
-    resources.push("/api/election/" + ElectionId + "/invite")
+    resources.push("/api/elections/" + ElectionId + "/invite")
     payloads.push({"email": email})
     inviteKeys.push(key)
   }
@@ -125,7 +125,7 @@ function sendInvites() {
 
 function loadElectorate(electionId, onSuccessFunction) {
   Piv.http.get([
-    '/api/election/' + electionId + '/voter_details',
+    '/api/elections/' + electionId + '/voter_details',
   ], onSuccessFunction)
 }
 
@@ -294,7 +294,7 @@ function deleteSelectedElectors() {
 
   var resources = [], electorVobjectKeys = []
   for (var key in CheckedElectorCheckboxes) {
-    resources.push("/api/election/" + ElectionId + "/elector/" + CheckedElectorCheckboxes[key].elector_id)
+    resources.push("/api/elections/" + ElectionId + "/electors/" + CheckedElectorCheckboxes[key].elector_id)
     electorVobjectKeys.push(key)
   }
   Piv.http.delete(resources, function() {

--- a/public/js/myElections.js
+++ b/public/js/myElections.js
@@ -15,7 +15,7 @@ Piv.removeHrefsForCurrentLoc()  //remove hrefs that link to the current page
 
 View.setHeader("My Elections")
 
-Piv.http.get(["/api/election/", "/api/invite/acceptable"], showAllMyElections)
+Piv.http.get(["/api/elections/", "/api/invite/acceptable"], showAllMyElections)
 
 
 function showAllMyElections(elections, invitesData) {
@@ -64,7 +64,7 @@ function showElection(container, name, id, canVote, canViewResults, canEdit, inv
 
   if (defaultButton) { linkElsOnHover(defaultButton, nameButton, "hover1") }
 
-  Piv.http.get(["/api/election/" + id + "/result"], function() { resultsButton.style.visibility = null })  //noe revert
+  Piv.http.get(["/api/elections/" + id + "/result"], function() { resultsButton.style.visibility = null })  //noe revert
 
 }
 function linkElsOnHover(el1, el2, hoverclass) {

--- a/public/js/pivotlib.js
+++ b/public/js/pivotlib.js
@@ -15,7 +15,7 @@ view.setHeader = function(text, election, delim) {
   mainheader.innerHTML = text
   if (election) {
     delim = delim || ": "
-    http.get(["/api/election/" + election], function(electionDetails) {
+    http.get(["/api/elections/" + election], function(electionDetails) {
       mainheader.innerHTML = text + delim + electionDetails.name
     })
   }
@@ -27,7 +27,7 @@ var loadBallot = lib.loadBallot = function(electionId, onSuccessFunction, perCan
   var onLoadBallotDataFunc = function(ballotDef, userRankings) {
     onSuccessFunction(ballotDef, userRankings, perCandidateFunc)
   }
-  getMultResources(['/api/election/' + electionId + '/candidate', '/api/election/' + electionId + '/batchvote'], onLoadBallotDataFunc)
+  getMultResources(['/api/elections/' + electionId + '/candidates', '/api/elections/' + electionId + '/batchvote'], onLoadBallotDataFunc)
 }
 var displayBallot = lib.displayBallot = function(ballotDefinition, rankedBallot, perCandidateFunc) {
   var candidate, sortedDefinitions = {}, sortedCandidates = {}

--- a/public/js/results.js
+++ b/public/js/results.js
@@ -12,7 +12,7 @@ View.setHeader("Results", ElectionId)
 
 Piv.removeHrefsForCurrentLoc()  //remove hrefs that link to the current page
 
-Piv.http.get(["/api/election/" + ElectionId + "/result"], showElectionResults)
+Piv.http.get(["/api/elections/" + ElectionId + "/result"], showElectionResults)
 
 // function definitions
 function displayCandidate(parent, description, cost, tie) {

--- a/resources/views/elections.blade.php
+++ b/resources/views/elections.blade.php
@@ -9,7 +9,7 @@
 
 @section('scripts')
 <script>
-    axios.get('/api/election')
+    axios.get('/api/elections')
          .then(response => {
                    console.log(response.data);
              });

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Http\Request;
+use Illuminate\Routing\Router;
 use Illuminate\Support\Facades\Route;
 
 /*
@@ -18,27 +19,34 @@ Route::middleware('auth:api')->get('/user', function (Request $request) {
     return $request->user();
 });
 
-Route::resource('election', 'ElectionController', ['only' => ['index', 'store', 'show', 'update', 'destroy']]);
-Route::post('election/{election_id}/batchvote', 'ElectionController@batchvote')->name('election.batchvote');
-Route::get('election/{election_id}/batchvote', 'ElectionController@batchvote_view')->name('election.batchvote_view');
-Route::get('election/{election_id}/get_ready', 'ElectionController@get_ready')->name('election.get_ready');
-Route::post('election/{election_id}/set_ready', 'ElectionController@set_ready')->name('election.set_ready');
-Route::get('election/{election_id}/voter_stats', 'ElectionController@voter_stats')->name('election.voter_stats');
-Route::get('election/{election_id}/voter_details', 'ElectionController@voter_details')->name('election.voter_details');
-Route::post('election/{election_id}/batch_candidates', 'ElectionController@batch_candidates')->name('election.batch_candidates');
-Route::get('election/{election_id}/batch_candidates', 'ElectionController@batch_candidates_view')->name('election.batch_candidates_view');
+Route::group(['middleware' => 'auth:api'], function (Router $api) {
 
-// TODO: allow update (e.g., to fix typos in candidate name?)
-Route::resource('election.candidate', 'CandidateController', ['only' => ['index', 'show', 'store', 'destroy']]);
+    $api->apiResource('elections', 'ElectionController');
+    $api->group(['prefix' => 'elections/{election}'], function (Router $api) {
+        $api->post('batchvote', 'ElectionController@batchvote')->name('election.batchvote');
+        $api->get('batchvote', 'ElectionController@batchvote_view')->name('election.batchvote_view');
+        $api->get('get_ready', 'ElectionController@get_ready')->name('election.get_ready');
+        $api->post('set_ready', 'ElectionController@set_ready')->name('election.set_ready');
+        $api->get('voter_stats', 'ElectionController@voter_stats')->name('election.voter_stats');
+        $api->get('voter_details', 'ElectionController@voter_details')->name('election.voter_details');
+        $api->post('batch_candidates', 'ElectionController@batch_candidates')->name('election.batch_candidates');
+        $api->get('batch_candidates', 'ElectionController@batch_candidates_view')->name('election.batch_candidates_view');
 
-Route::resource('election.elector', 'ElectorController', ['only' => ['index', 'show', 'destroy']]);
 
-// TODO: get rid of election result, moving call to election controller
-Route::resource('election.result', 'ResultController', ['only' => ['index']]);
+        // TODO: allow update (e.g., to fix typos in candidate name?)
+        $api->resource('candidate', 'CandidateController', ['only' => ['index', 'show', 'store', 'destroy']]);
 
-Route::resource('election.invite', 'InviteController', ['only' => ['index', 'store']]);
-Route::post('/invite/acceptable', 'InviteController@acceptable')->name('invite.acceptable'); // TODO: remove this (use GET instead)
-Route::get('/invite/acceptable', 'InviteController@acceptable')->name('invite.acceptable');
-Route::post('/invite/accept', 'InviteController@accept')->name('invite.accept');
+        $api->resource('elector', 'ElectorController', ['only' => ['index', 'show', 'destroy']]);
 
-Route::post('/delete_account', 'AccountController@delete_account')->name('account.delete');
+        // TODO: get rid of election result, moving call to election controller
+        $api->resource('result', 'ResultController', ['only' => ['index']]);
+
+        $api->resource('invite', 'InviteController', ['only' => ['index', 'store']]);
+    });
+
+    $api->post('/invite/acceptable', 'InviteController@acceptable')->name('invite.acceptable'); // TODO: remove this (use GET instead)
+    $api->get('/invite/acceptable', 'InviteController@acceptable')->name('invite.acceptable');
+    $api->post('/invite/accept', 'InviteController@accept')->name('invite.accept');
+
+    $api->post('/delete_account', 'AccountController@delete_account')->name('account.delete');
+});

--- a/routes/api.php
+++ b/routes/api.php
@@ -34,7 +34,7 @@ Route::group(['middleware' => 'auth:api'], function (Router $api) {
 
 
         // TODO: allow update (e.g., to fix typos in candidate name?)
-        $api->resource('candidate', 'CandidateController', ['only' => ['index', 'show', 'store', 'destroy']]);
+        $api->resource('candidates', 'CandidateController', ['only' => ['index', 'show', 'store', 'destroy']]);
 
         $api->resource('electors', 'ElectorController', ['only' => ['index', 'show', 'destroy']]);
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -32,9 +32,7 @@ Route::group(['middleware' => 'auth:api'], function (Router $api) {
         $api->post('batch_candidates', 'ElectionController@batch_candidates')->name('election.batch_candidates');
         $api->get('batch_candidates', 'ElectionController@batch_candidates_view')->name('election.batch_candidates_view');
 
-
-        // TODO: allow update (e.g., to fix typos in candidate name?)
-        $api->resource('candidates', 'CandidateController', ['only' => ['index', 'show', 'store', 'destroy']]);
+        $api->apiResource('candidates', 'CandidateController');
 
         $api->resource('electors', 'ElectorController', ['only' => ['index', 'show', 'destroy']]);
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -36,7 +36,7 @@ Route::group(['middleware' => 'auth:api'], function (Router $api) {
         // TODO: allow update (e.g., to fix typos in candidate name?)
         $api->resource('candidate', 'CandidateController', ['only' => ['index', 'show', 'store', 'destroy']]);
 
-        $api->resource('elector', 'ElectorController', ['only' => ['index', 'show', 'destroy']]);
+        $api->resource('electors', 'ElectorController', ['only' => ['index', 'show', 'destroy']]);
 
         // TODO: get rid of election result, moving call to election controller
         $api->resource('result', 'ResultController', ['only' => ['index']]);

--- a/storage/api-docs/api-docs.json
+++ b/storage/api-docs/api-docs.json
@@ -6,7 +6,7 @@
     },
     "basePath": "/api",
     "paths": {
-        "/elections/{electionId}/candidate": {
+        "/elections/{electionId}/candidates": {
             "get": {
                 "tags": [
                     "Candidates"
@@ -80,7 +80,7 @@
                 }
             }
         },
-        "/elections/{electionId}/candidate/{candidateId}": {
+        "/elections/{electionId}/candidates/{candidateId}": {
             "get": {
                 "tags": [
                     "Candidates"
@@ -141,6 +141,45 @@
                         "description": "Candidate ID to delete",
                         "required": true,
                         "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "successful operation"
+                    },
+                    "400": {
+                        "description": "Bad Request"
+                    }
+                }
+            },
+            "patch": {
+                "tags": [
+                    "Candidates"
+                ],
+                "summary": "Update a candidate",
+                "operationId": "updateCandidate",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "electionId",
+                        "in": "path",
+                        "description": "Election ID",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "name": "payload",
+                        "in": "body",
+                        "description": "Candidate to add",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/CreateCandidate"
+                        }
                     }
                 ],
                 "responses": {

--- a/storage/api-docs/api-docs.json
+++ b/storage/api-docs/api-docs.json
@@ -6,7 +6,7 @@
     },
     "basePath": "/api",
     "paths": {
-        "/election/{electionId}/candidate": {
+        "/elections/{electionId}/candidate": {
             "get": {
                 "tags": [
                     "Candidates"
@@ -80,7 +80,7 @@
                 }
             }
         },
-        "/election/{electionId}/candidate/{candidateId}": {
+        "/elections/{electionId}/candidate/{candidateId}": {
             "get": {
                 "tags": [
                     "Candidates"
@@ -153,7 +153,7 @@
                 }
             }
         },
-        "/election": {
+        "/elections": {
             "get": {
                 "tags": [
                     "Election"
@@ -176,7 +176,7 @@
                 }
             }
         },
-        "/election/{electionId}": {
+        "/elections/{electionId}": {
             "get": {
                 "tags": [
                     "Election"
@@ -208,7 +208,7 @@
                 }
             }
         },
-        "/election/{electionId}/elector": {
+        "/elections/{electionId}/elector": {
             "get": {
                 "tags": [
                     "Electors"
@@ -240,7 +240,7 @@
                 }
             }
         },
-        "/election/{electionId}/elector/{electorId}": {
+        "/elections/{electionId}/elector/{electorId}": {
             "get": {
                 "tags": [
                     "Electors"
@@ -276,12 +276,12 @@
                 }
             }
         },
-        "/election/{electionId}/invite": {
+        "/elections/{electionId}/invite": {
             "get": {
                 "tags": [
                     "Invites"
                 ],
-                "summary": "View pending invites",
+                "summary": "View electors who have not accepted their invite yet",
                 "operationId": "inviteIndex",
                 "parameters": [
                     {
@@ -343,79 +343,6 @@
                         "schema": {
                             "$ref": "#/definitions/Invite"
                         }
-                    },
-                    "400": {
-                        "description": "Bad Request"
-                    }
-                }
-            }
-        },
-        "/election/{electionId}/invite/{code}": {
-            "get": {
-                "tags": [
-                    "Invites"
-                ],
-                "summary": "Get information about an invite",
-                "operationId": "getInviteByCode",
-                "parameters": [
-                    {
-                        "name": "electionId",
-                        "in": "path",
-                        "description": "Election to get",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "name": "code",
-                        "in": "path",
-                        "description": "Invite to get",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Success",
-                        "schema": {
-                            "$ref": "#/definitions/Invite"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request"
-                    }
-                }
-            },
-            "delete": {
-                "tags": [
-                    "Invites"
-                ],
-                "summary": "Delete an invite",
-                "operationId": "deleteInvite",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "name": "electionId",
-                        "in": "path",
-                        "description": "Election ID",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "name": "code",
-                        "in": "path",
-                        "description": "Invite Code",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "successful operation"
                     },
                     "400": {
                         "description": "Bad Request"

--- a/storage/api-docs/api-docs.json
+++ b/storage/api-docs/api-docs.json
@@ -208,7 +208,7 @@
                 }
             }
         },
-        "/elections/{electionId}/elector": {
+        "/elections/{electionId}/electors": {
             "get": {
                 "tags": [
                     "Electors"
@@ -240,7 +240,7 @@
                 }
             }
         },
-        "/elections/{electionId}/elector/{electorId}": {
+        "/elections/{electionId}/electors/{electorId}": {
             "get": {
                 "tags": [
                     "Electors"

--- a/tests/Feature/CandidateTest.php
+++ b/tests/Feature/CandidateTest.php
@@ -1,0 +1,554 @@
+<?php
+
+
+namespace Tests\Feature;
+
+
+use App\Candidate;
+use App\Election;
+use App\Elector;
+use App\User;
+use Carbon\Carbon;
+use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Auth\AuthenticationException;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Collection;
+use Illuminate\Validation\ValidationException;
+use Tests\TestCase;
+
+class CandidateTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    /** @test */
+    public function cannot_get_a_candidate_if_not_creator_or_elector()
+    {
+        $user = factory(User::class)->create();
+
+        $election = factory(Election::class)->create();
+
+        $candidate = factory(Candidate::class)->create([
+            'election_id' => $election->id
+        ]);
+
+        $response = $this->actingAs($user, 'api')->getJson("api/elections/{$election->id}/candidates/{$candidate->id}");
+
+        $response->assertStatus(400);
+        $this->assertInstanceOf(AuthorizationException::class, $response->exception);
+    }
+
+    /** @test */
+    public function cannot_get_a_candidate_if_guest()
+    {
+        $election = factory(Election::class)->create();
+
+        $candidate = factory(Candidate::class)->create([
+            'election_id' => $election->id
+        ]);
+
+        $response = $this->getJson("api/elections/{$election->id}/candidates/{$candidate->id}");
+
+        $response->assertStatus(400);
+        $this->assertInstanceOf(AuthenticationException::class, $response->exception);
+    }
+
+    /** @test */
+    public function can_get_a_candidate_if_elector()
+    {
+        $user = factory(User::class)->create();
+
+        $election = factory(Election::class)->create();
+
+        $candidate = factory(Candidate::class)->create([
+            'election_id' => $election->id
+        ]);
+
+        // Accepted invite
+        $electorA = factory(Elector::class)->create([
+            'user_id' => $user->id,
+            'election_id' => $election->id,
+            'invite_accepted_at' => Carbon::now()
+        ]);
+
+        $response = $this->actingAs($user, 'api')->getJson("api/elections/{$election->id}/candidates/{$candidate->id}");
+
+        $response->assertStatus(200);
+        $responseCandidate = $response->getOriginalContent();
+        $this->assertTrue($candidate->is($responseCandidate));
+    }
+
+    /** @test */
+    public function can_get_a_candidate_if_creator()
+    {
+        $user = factory(User::class)->create();
+
+        $election = factory(Election::class)->create([
+            'creator_id' => $user->id
+        ]);
+
+        $candidate = factory(Candidate::class)->create([
+            'election_id' => $election->id
+        ]);
+
+        $response = $this->actingAs($user, 'api')->getJson("api/elections/{$election->id}/candidates/{$candidate->id}");
+
+        $response->assertStatus(200);
+        $responseCandidate = $response->getOriginalContent();
+        $this->assertTrue($candidate->is($responseCandidate));
+    }
+
+
+    /** @test */
+    public function cannot_get_all_candidates_if_not_creator_or_elector()
+    {
+        $user = factory(User::class)->create();
+
+        $election = factory(Election::class)->create();
+
+        $candidate = factory(Candidate::class)->times(5)->create([
+            'election_id' => $election->id
+        ]);
+
+        $response = $this->actingAs($user, 'api')->getJson("api/elections/{$election->id}/candidates");
+
+        $response->assertStatus(400);
+        $this->assertInstanceOf(AuthorizationException::class, $response->exception);
+    }
+
+    /** @test */
+    public function cannot_get_all_candidates_if_guest()
+    {
+        $election = factory(Election::class)->create();
+
+
+        $response = $this->getJson("api/elections/{$election->id}/candidates");
+
+        $response->assertStatus(400);
+        $this->assertInstanceOf(AuthenticationException::class, $response->exception);
+    }
+
+    /** @test */
+    public function can_get_all_candidates_if_elector()
+    {
+        $user = factory(User::class)->create();
+
+        $election = factory(Election::class)->create();
+
+        $candidates = factory(Candidate::class)->times(5)->create([
+            'election_id' => $election->id
+        ]);
+
+        // Accepted invite
+        $electorA = factory(Elector::class)->create([
+            'user_id' => $user->id,
+            'election_id' => $election->id,
+            'invite_accepted_at' => Carbon::now()
+        ]);
+
+        $response = $this->actingAs($user, 'api')->getJson("api/elections/{$election->id}/candidates");
+
+        $response->assertStatus(200);
+        $responseCandidates = $response->getOriginalContent();
+
+        $this->assertContainsAllModels($candidates, $responseCandidates);
+    }
+
+    /** @test */
+    public function can_get_all_candidates_if_creator()
+    {
+        $user = factory(User::class)->create();
+
+        $election = factory(Election::class)->create([
+            'creator_id' => $user->id
+        ]);
+
+        $candidates = factory(Candidate::class)->times(5)->create([
+            'election_id' => $election->id
+        ]);
+
+        $response = $this->actingAs($user, 'api')->getJson("api/elections/{$election->id}/candidates");
+
+        $response->assertStatus(200);
+        $responseCandidates = $response->getOriginalContent();
+
+        $this->assertContainsAllModels($candidates, $responseCandidates);
+    }
+
+    /** @test */
+    public function cannot_get_candidates_in_other_election_if_elector()
+    {
+        $user = factory(User::class)->create();
+
+        $election = factory(Election::class)->create();
+        $otherElection = factory(Election::class)->create();
+
+        $candidates = factory(Candidate::class)->times(5)->create([
+            'election_id' => $election->id
+        ]);
+        $candidatesInOtherElection = factory(Candidate::class)->times(5)->create([
+            'election_id' => $otherElection->id
+        ]);
+
+        // Accepted invite
+        $electorA = factory(Elector::class)->create([
+            'user_id' => $user->id,
+            'election_id' => $election->id,
+            'invite_accepted_at' => Carbon::now()
+        ]);
+
+        $response = $this->actingAs($user, 'api')->getJson("api/elections/{$otherElection->id}/candidates");
+
+        $response->assertStatus(400);
+        $this->assertInstanceOf(AuthorizationException::class, $response->exception);
+    }
+
+    /** @test */
+    public function cannot_get_candidates_in_other_election_if_creator()
+    {
+        $user = factory(User::class)->create();
+
+        $election = factory(Election::class)->create([
+            'creator_id' => $user->id
+        ]);
+        $otherElection = factory(Election::class)->create();
+
+        $candidates = factory(Candidate::class)->times(5)->create([
+            'election_id' => $election->id
+        ]);
+        $candidatesInOtherElection = factory(Candidate::class)->times(5)->create([
+            'election_id' => $otherElection->id
+        ]);
+
+        $response = $this->actingAs($user, 'api')->getJson("api/elections/{$otherElection->id}/candidates");
+
+        $response->assertStatus(400);
+        $this->assertInstanceOf(AuthorizationException::class, $response->exception);
+    }
+
+    /** @test */
+    public function cannot_get_a_candidate_in_other_election_if_creator()
+    {
+        $user = factory(User::class)->create();
+
+        $election = factory(Election::class)->create([
+            'creator_id' => $user->id
+        ]);
+        $otherElection = factory(Election::class)->create();
+
+        $candidate = factory(Candidate::class)->create([
+            'election_id' => $election->id
+        ]);
+        $candidateInOtherElection = factory(Candidate::class)->create([
+            'election_id' => $otherElection->id
+        ]);
+
+        // Trying to access the other candidate in other election through the other election
+        $response = $this->actingAs($user, 'api')->getJson("api/elections/{$otherElection->id}/candidates/{$candidateInOtherElection->id}");
+
+        $response->assertStatus(400);
+        $this->assertInstanceOf(AuthorizationException::class, $response->exception);
+
+        //$this->disableExceptionHandling();
+
+        // Trying to access the other candidate in other election through the election with access to.
+        $response = $this->actingAs($user, 'api')->getJson("api/elections/{$election->id}/candidates/{$candidateInOtherElection->id}");
+
+        $response->assertStatus(404);
+        $this->assertInstanceOf(ModelNotFoundException::class, $response->exception);
+    }
+
+    /** @test */
+    public function cannot_get_a_candidate_in_other_election_if_elector()
+    {
+        $user = factory(User::class)->create();
+
+        $election = factory(Election::class)->create();
+        $otherElection = factory(Election::class)->create();
+
+        $candidate = factory(Candidate::class)->create([
+            'election_id' => $election->id
+        ]);
+        $candidateInOtherElection = factory(Candidate::class)->create([
+            'election_id' => $otherElection->id
+        ]);
+
+        // Accepted invite
+        $electorA = factory(Elector::class)->create([
+            'user_id' => $user->id,
+            'election_id' => $election->id,
+            'invite_accepted_at' => Carbon::now()
+        ]);
+
+        // Trying to access the other candidate in other election through the other election
+        $response = $this->actingAs($user, 'api')->getJson("api/elections/{$otherElection->id}/candidates/{$candidateInOtherElection->id}");
+
+        $response->assertStatus(400);
+        $this->assertInstanceOf(AuthorizationException::class, $response->exception);
+
+        // Trying to access the other candidate in other election through the election with access to.
+        $response = $this->actingAs($user, 'api')->getJson("api/elections/{$election->id}/candidates/{$candidateInOtherElection->id}");
+
+        $response->assertStatus(404);
+        $this->assertInstanceOf(ModelNotFoundException::class, $response->exception);
+    }
+
+    /** @test */
+    public function can_delete_a_candidate_if_creator()
+    {
+        $user = factory(User::class)->create();
+
+        $election = factory(Election::class)->create([
+            'creator_id' => $user->id,
+            'ballot_version' => 1
+        ]);
+
+        $candidate = factory(Candidate::class)->create([
+            'election_id' => $election->id
+        ]);
+
+        // Trying to access the other candidate in other election through the other election
+        $response = $this->actingAs($user, 'api')->deleteJson("api/elections/{$election->id}/candidates/{$candidate->id}");
+
+        $response->assertStatus(204);
+        $this->assertEquals(2, $election->fresh()->ballot_version);
+        $this->assertEmpty($election->candidates);
+    }
+
+    /** @test */
+    public function cannot_delete_a_candidate_if_elector()
+    {
+        $user = factory(User::class)->create();
+        $election = factory(Election::class)->create();
+        $candidate = factory(Candidate::class)->create([
+            'election_id' => $election->id
+        ]);
+        // Accepted invite
+        $elector = factory(Elector::class)->create([
+            'user_id' => $user->id,
+            'election_id' => $election->id,
+            'invite_accepted_at' => Carbon::now()
+        ]);
+
+        // Trying to access the other candidate in other election through the other election
+        $response = $this->actingAs($user, 'api')->deleteJson("api/elections/{$election->id}/candidates/{$candidate->id}");
+
+        $response->assertStatus(400);
+        $this->assertInstanceOf(AuthorizationException::class, $response->exception);
+        $this->assertCount(1, $election->fresh()->candidates);
+    }
+
+    /** @test */
+    public function cannot_delete_a_candidate_if_guest()
+    {
+        $user = factory(User::class)->create();
+        $election = factory(Election::class)->create();
+        $candidate = factory(Candidate::class)->create([
+            'election_id' => $election->id
+        ]);
+
+        // Trying to access the other candidate in other election through the other election
+        $response = $this->actingAs($user, 'api')->deleteJson("api/elections/{$election->id}/candidates/{$candidate->id}");
+
+        $response->assertStatus(400);
+        $this->assertInstanceOf(AuthorizationException::class, $response->exception);
+        $this->assertCount(1, $election->fresh()->candidates);
+    }
+
+    /** @test */
+    public function cannot_delete_a_candidate_in_other_election_if_has_access()
+    {
+        $user = factory(User::class)->create();
+
+        $election = factory(Election::class)->create([
+            'creator_id' => $user->id
+        ]);
+        $otherElection = factory(Election::class)->create();
+
+        $candidate = factory(Candidate::class)->create([
+            'election_id' => $election->id
+        ]);
+        $candidateInOtherElection = factory(Candidate::class)->create([
+            'election_id' => $otherElection->id
+        ]);
+
+        // Trying to access the other candidate in other election through the other election
+        $response = $this->actingAs($user, 'api')->deleteJson("api/elections/{$election->id}/candidates/{$candidateInOtherElection->id}");
+
+        $response->assertStatus(404);
+        $this->assertInstanceOf(ModelNotFoundException::class, $response->exception);
+        $this->assertCount(1, $election->fresh()->candidates);
+    }
+
+    /** @test */
+    public function can_update_a_candidates_name_if_creator()
+    {
+        $user = factory(User::class)->create();
+
+        $election = factory(Election::class)->create([
+            'creator_id' => $user->id,
+            'ballot_version' => 1
+        ]);
+
+        $candidate = factory(Candidate::class)->create([
+            'election_id' => $election->id,
+            'name' => "old name",
+        ]);
+
+        // Trying to access the other candidate in other election through the other election
+        $response = $this->actingAs($user, 'api')->patchJson("api/elections/{$election->id}/candidates/{$candidate->id}", [
+            'name' => "new name"
+        ]);
+
+        $response->assertStatus(204);
+        $this->assertEquals(1, $election->fresh()->ballot_version);
+        $this->assertEquals("new name", $candidate->fresh()->name);
+    }
+
+    /** @test */
+    public function cannot_update_a_candidate_if_no_name_is_specified()
+    {
+        $user = factory(User::class)->create();
+
+        $election = factory(Election::class)->create([
+            'creator_id' => $user->id,
+            'ballot_version' => 1
+        ]);
+
+        $candidate = factory(Candidate::class)->create([
+            'election_id' => $election->id,
+            'name' => "old name",
+        ]);
+
+        // Trying to access the other candidate in other election through the other election
+        $response = $this->actingAs($user, 'api')->patchJson("api/elections/{$election->id}/candidates/{$candidate->id}", [
+
+        ]);
+
+        $response->assertStatus(400);
+        $this->assertInstanceOf(ValidationException::class, $response->exception);
+        $this->assertEquals(1, $election->fresh()->ballot_version);
+        $this->assertEquals("old name", $candidate->fresh()->name);
+    }
+
+    /** @test */
+    public function cannot_update_a_candidate_if_elector()
+    {
+        $user = factory(User::class)->create();
+
+        $election = factory(Election::class)->create([
+            'ballot_version' => 1
+        ]);
+
+        $candidate = factory(Candidate::class)->create([
+            'election_id' => $election->id,
+            'name' => "old name",
+        ]);
+
+        // Accepted invite
+        $elector = factory(Elector::class)->create([
+            'user_id' => $user->id,
+            'election_id' => $election->id,
+            'invite_accepted_at' => Carbon::now()
+        ]);
+
+        // Trying to access the other candidate in other election through the other election
+        $response = $this->actingAs($user, 'api')->patchJson("api/elections/{$election->id}/candidates/{$candidate->id}", [
+            'name' => "new name"
+        ]);
+
+        $response->assertStatus(400);
+        $this->assertEquals(1, $election->fresh()->ballot_version);
+        $this->assertEquals("old name", $candidate->fresh()->name);
+    }
+
+    /** @test */
+    public function cannot_update_a_candidate_if_guest()
+    {
+        $user = factory(User::class)->create();
+
+        $election = factory(Election::class)->create([
+            'ballot_version' => 1
+        ]);
+
+        $candidate = factory(Candidate::class)->create([
+            'election_id' => $election->id,
+            'name' => "old name",
+        ]);
+
+        // Trying to access the other candidate in other election through the other election
+        $response = $this->actingAs($user, 'api')->patchJson("api/elections/{$election->id}/candidates/{$candidate->id}", [
+            'name' => "new name"
+        ]);
+
+        $response->assertStatus(400);
+        $this->assertEquals(1, $election->fresh()->ballot_version);
+        $this->assertEquals("old name", $candidate->fresh()->name);
+    }
+
+    /** @test */
+    public function can_create_a_candidate_if_creator()
+    {
+        $user = factory(User::class)->create();
+
+        $election = factory(Election::class)->create([
+            'creator_id' => $user->id,
+            'ballot_version' => 1
+        ]);
+
+        // Trying to access the other candidate in other election through the other election
+        $response = $this->actingAs($user, 'api')->postJson("api/elections/{$election->id}/candidates", [
+            'name' => "new name"
+        ]);
+
+        $response->assertStatus(201);
+        $this->assertEquals(2, $election->fresh()->ballot_version);
+        $this->assertEquals("new name", $response->getOriginalContent()->name);
+    }
+
+    /** @test */
+    public function cannot_create_a_candidate_if_elector()
+    {
+        $user = factory(User::class)->create();
+
+        $election = factory(Election::class)->create([
+            'ballot_version' => 1
+        ]);
+
+        // Accepted invite
+        $elector = factory(Elector::class)->create([
+            'user_id' => $user->id,
+            'election_id' => $election->id,
+            'invite_accepted_at' => Carbon::now()
+        ]);
+
+        // Trying to access the other candidate in other election through the other election
+        $response = $this->actingAs($user, 'api')->postJson("api/elections/{$election->id}/candidates", [
+            'name' => "new name"
+        ]);
+
+        $response->assertStatus(400);
+        $this->assertInstanceOf(AuthorizationException::class, $response->exception);
+        $this->assertEquals(1, $election->fresh()->ballot_version);
+    }
+
+    /** @test */
+    public function cannot_create_a_candidate_if_guest()
+    {
+        $user = factory(User::class)->create();
+
+        $election = factory(Election::class)->create([
+            'ballot_version' => 1
+        ]);
+
+        // Trying to access the other candidate in other election through the other election
+        $response = $this->actingAs($user, 'api')->postJson("api/elections/{$election->id}/candidates", [
+            'name' => "new name"
+        ]);
+
+        $response->assertStatus(400);
+        $this->assertInstanceOf(AuthorizationException::class, $response->exception);
+        $this->assertEquals(1, $election->fresh()->ballot_version);
+    }
+
+}

--- a/tests/Feature/ElectorTest.php
+++ b/tests/Feature/ElectorTest.php
@@ -40,7 +40,7 @@ class ElectorTest extends TestCase
             'invite_accepted_at' => Carbon::now()
         ]);
 
-        $response = $this->actingAs($user, 'api')->getJson("api/election/{$election->id}/elector");
+        $response = $this->actingAs($user, 'api')->getJson("api/elections/{$election->id}/electors");
 
         $response->assertStatus(200);
         $electors = $response->getOriginalContent();
@@ -73,7 +73,7 @@ class ElectorTest extends TestCase
             'invite_accepted_at' => Carbon::now()
         ]);
 
-        $response = $this->actingAs($user, 'api')->getJson("api/election/{$election->id}/elector/{$electorA->id}");
+        $response = $this->actingAs($user, 'api')->getJson("api/elections/{$election->id}/electors/{$electorA->id}");
 
         $response->assertStatus(200);
         $this->assertTrue($electorA->is($response->getOriginalContent()));
@@ -104,7 +104,7 @@ class ElectorTest extends TestCase
             'invite_accepted_at' => Carbon::now()
         ]);
 
-        $response = $this->actingAs($user, 'api')->getJson("api/election/{$election->id}/elector/{$electorWithoutUser->id}");
+        $response = $this->actingAs($user, 'api')->getJson("api/elections/{$election->id}/electors/{$electorWithoutUser->id}");
 
         $this->assertInstanceOf(ModelNotFoundException::class, $response->exception);
     }
@@ -135,7 +135,7 @@ class ElectorTest extends TestCase
             'invite_accepted_at' => Carbon::now()
         ]);
 
-        $response = $this->actingAs($user, 'api')->getJson("api/election/{$election->id}/elector/{$electorNotInElection->id}");
+        $response = $this->actingAs($user, 'api')->getJson("api/elections/{$election->id}/electors/{$electorNotInElection->id}");
 
         $this->assertInstanceOf(ModelNotFoundException::class, $response->exception);
     }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -3,8 +3,10 @@
 namespace Tests;
 
 use Illuminate\Contracts\Debug\ExceptionHandler;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
 use App\Exceptions\Handler;
+use Illuminate\Support\Collection;
 
 
 abstract class TestCase extends BaseTestCase
@@ -25,5 +27,20 @@ abstract class TestCase extends BaseTestCase
                 throw $e;
             }
         });
+    }
+
+    protected function assertContainsAllModels(Collection $models, Collection $responseModel)
+    {
+        $responseModel->each(function (Model $responseModel) use ($models) {
+            $contains = $models->contains(function (Model $model) use ($responseModel) {
+                return $model->is($responseModel);
+            });
+            $this->assertTrue($contains, "Model [{$responseModel->getKey()}] is not in the collection");
+        });
+    }
+
+    protected function assertModelIsSame(Model $origin, Model $other)
+    {
+        $this->assertTrue($origin->is($other), "Models are not equals");
     }
 }

--- a/tests/python/.gitignore
+++ b/tests/python/.gitignore
@@ -1,2 +1,3 @@
 users.json
 .idea
+dump.html

--- a/tests/python/tests.py
+++ b/tests/python/tests.py
@@ -139,7 +139,7 @@ class API:
         try:
             return_data = json.loads(d)
         except:
-            if self.next_should_fail:
+            if self.next_should_fail or d == "":
                 self.next_should_fail = False
                 return
             else:

--- a/tests/python/tests.py
+++ b/tests/python/tests.py
@@ -162,23 +162,23 @@ class API:
         return self.user_delete(user, url)
 
     def get_candidates(self, user, election):
-        url = 'elections/%d/candidate' % election['id']
+        url = 'elections/%d/candidates' % election['id']
         return self.user_get(user, url)
 
     def get_electors(self, user, election):
-        url = 'elections/%d/elector' % election['id']
+        url = 'elections/%d/electors' % election['id']
         return self.user_get(user, url)
 
     def create_candidate(self, user, election, name):
-        url = 'elections/%d/candidate' % election['id']
+        url = 'elections/%d/candidates' % election['id']
         return self.user_post(user, url, {"name": name})
 
     def delete_candidate(self, user, election, candidate):
-        url = 'elections/%d/candidate/%d' % (election['id'], candidate['id'])
+        url = 'elections/%d/candidates/%d' % (election['id'], candidate['id'])
         return self.user_delete(user, url)
 
     def set_rank(self, user, election, candidate, rank):
-        url = 'elections/%d/candidate/%d/rank' % (election['id'], candidate['id'])
+        url = 'elections/%d/candidates/%d/rank' % (election['id'], candidate['id'])
         return self.user_post(user, url, {"rank": rank})
 
     def invite(self, user, election, email):

--- a/tests/python/tests.py
+++ b/tests/python/tests.py
@@ -152,37 +152,37 @@ class API:
 
     # pivot API wrappers
     def get_elections(self, user):
-        return self.user_get(user, 'election')
+        return self.user_get(user, 'elections')
 
     def create_election(self, user, name):
-        return self.user_post(user, 'election', {"name": name})
+        return self.user_post(user, 'elections', {"name": name})
 
     def delete_election(self, user, election):
-        url = 'election/%d' % election['id']
+        url = 'elections/%d' % election['id']
         return self.user_delete(user, url)
 
     def get_candidates(self, user, election):
-        url = 'election/%d/candidate' % election['id']
+        url = 'elections/%d/candidate' % election['id']
         return self.user_get(user, url)
 
     def get_electors(self, user, election):
-        url = 'election/%d/elector' % election['id']
+        url = 'elections/%d/elector' % election['id']
         return self.user_get(user, url)
 
     def create_candidate(self, user, election, name):
-        url = 'election/%d/candidate' % election['id']
+        url = 'elections/%d/candidate' % election['id']
         return self.user_post(user, url, {"name": name})
 
     def delete_candidate(self, user, election, candidate):
-        url = 'election/%d/candidate/%d' % (election['id'], candidate['id'])
+        url = 'elections/%d/candidate/%d' % (election['id'], candidate['id'])
         return self.user_delete(user, url)
 
     def set_rank(self, user, election, candidate, rank):
-        url = 'election/%d/candidate/%d/rank' % (election['id'], candidate['id'])
+        url = 'elections/%d/candidate/%d/rank' % (election['id'], candidate['id'])
         return self.user_post(user, url, {"rank": rank})
 
     def invite(self, user, election, email):
-        url = 'election/%d/invite' % (election['id'])
+        url = 'elections/%d/invite' % (election['id'])
         return self.user_post(user, url, {"email": email})
 
     def accept(self, user, code):
@@ -194,23 +194,23 @@ class API:
         return self.user_get(user, url)
 
     def election_result(self, user, election):
-        url = 'election/%d/result' % election['id']
+        url = 'elections/%d/result' % election['id']
         return self.user_get(user, url)
 
     def batchvote(self, user, election, votes):
-        url = 'election/%d/batchvote' % election['id']
+        url = 'elections/%d/batchvote' % election['id']
         return self.user_post(user, url, {'votes': votes})
 
     def batchvote_view(self, user, election):
-        url = 'election/%d/batchvote' % election['id']
+        url = 'elections/%d/batchvote' % election['id']
         return self.user_get(user, url)
 
     def batch_candidates(self, user, election, candidates):
-        url = 'election/%d/batch_candidates' % election['id']
+        url = 'elections/%d/batch_candidates' % election['id']
         return self.user_post(user, url, {'candidates': candidates})
 
     def batch_candidates_view(self, user, election):
-        url = 'election/%d/batch_candidates' % election['id']
+        url = 'elections/%d/batch_candidates' % election['id']
         return self.user_get(user, url)
 
     def add_elector(self, election, admin, user):
@@ -219,19 +219,19 @@ class API:
         self.accept(user, code)
 
     def get_ready(self, user, election):
-        url = 'election/%d/get_ready' % election['id']
+        url = 'elections/%d/get_ready' % election['id']
         return self.user_get(user, url)
 
     def set_ready(self, user, election, version):
-        url = 'election/%d/set_ready' % election['id']
+        url = 'elections/%d/set_ready' % election['id']
         return self.user_post(user, url, {'approved_version': version})
 
     def voter_stats(self, user, election):
-        url = 'election/%d/voter_stats' % election['id']
+        url = 'elections/%d/voter_stats' % election['id']
         return self.user_get(user, url)
 
     def voter_details(self, user, election):
-        url = 'election/%d/voter_details' % election['id']
+        url = 'elections/%d/voter_details' % election['id']
         return self.user_get(user, url)
 
 def test1(api):


### PR DESCRIPTION
Sorry for the big commit, should prob. had split it up in multiple commits.

- Changed election to electors in API for more restful syntax
- Changed candidate to candidates in API
- Changed election to elections in API
- Added tests for candidates API
- Updated test to the new endpoints
- Refactored api route file 
- Fixed a bug which allowed to delete and access electors in other elections then the one you had selected in API
- Added support for updating a electors name through API  (does not update ballot_version)
- Some small refactoring 
