### PR TITLE
Heavy-handed, ugly css hack to enable results page printing on Firefox.

### DIFF
--- a/public/css/pivot.css
+++ b/public/css/pivot.css
@@ -581,3 +581,11 @@ input[type=submit],
     width: 600px;
     height: 600px;
 }
+
+@media print {
+	body, div {
+		height: auto;
+		overflow: visible !important;
+		display: block;
+	}
+}


### PR DESCRIPTION
Addresses #218 .
This enables printing in Firefox. This makes me feel a little gross because the changes apply pretty indiscriminately to most HTML elements (present and future). Thanks to media queries, the ugliness is only restricted to the print view. If we can accept that this isn't super pretty or future-proof, it gets the job done.

Worth it?